### PR TITLE
Declared timeout_to_timespec() static - fixes an 'undefined symbol' error

### DIFF
--- a/ipcqueue/posixmq.c
+++ b/ipcqueue/posixmq.c
@@ -14,7 +14,7 @@
 #include "posixmq.h"
 
 
-void inline timeout_to_timespec(const double timeout,
+static void inline timeout_to_timespec(const double timeout,
         struct timespec * const abs_timeout) {
 
     struct timeval current_timeval;


### PR DESCRIPTION
I was getting "undefined symbol: timeout_to_timespec" when trying to create a posixmq.Queue object - this edit fixes it.