### PR TITLE
Add `oflag` option to the python interface 

### DIFF
--- a/cffi_builder_posix.py
+++ b/cffi_builder_posix.py
@@ -28,7 +28,7 @@ ffibuilder.cdef(
        ...;
     };
 
-    PosixMqResult posixmq_open(const char * const name, int * const mq,
+    PosixMqResult posixmq_open(const char * const name, int oflag, int * const mq,
             const size_t maxmsgsize, const size_t maxsize);
 
     PosixMqResult posixmq_close(const int mq);

--- a/ipcqueue/posixmq.c
+++ b/ipcqueue/posixmq.c
@@ -33,11 +33,11 @@ static void inline timeout_to_timespec(const double timeout,
     }
 }
 
-PosixMqResult posixmq_open(const char * const name, int * const mq,
+PosixMqResult posixmq_open(const char * const name, int oflag, int * const mq,
         const size_t maxmsgsize, const size_t maxsize) {
     struct mq_attr attrs = {.mq_maxmsg = maxsize, .mq_msgsize = maxmsgsize};
 
-    mqd_t mqdes = mq_open(name, O_CREAT | O_RDWR, 0644, &attrs);
+    mqd_t mqdes = mq_open(name, O_CREAT | oflag, 0644, &attrs);
 
     if (mqdes < 0) {
         switch (errno) {

--- a/ipcqueue/posixmq.h
+++ b/ipcqueue/posixmq.h
@@ -17,7 +17,7 @@ typedef enum {
     POSIXMQ_E_DOESNT_EXIST
 } PosixMqResult;
 
-PosixMqResult posixmq_open(const char * const name, int * const mq,
+PosixMqResult posixmq_open(const char * const name, int oflag, int * const mq,
         const size_t maxmsgsize, const size_t maxsize);
 
 PosixMqResult posixmq_close(const int mq);

--- a/ipcqueue/posixmq.py
+++ b/ipcqueue/posixmq.py
@@ -77,7 +77,8 @@ class Queue(object):
     def __init__(self, name, oflag=os.O_RDWR, maxsize=10, maxmsgsize=1024, serializer=PickleSerializer):
         """
         Constructor for message queue. *name* is an unique identifier of the
-        queue, must starts with ``/``. *maxsize* is an integer that sets
+        queue, must starts with ``/``. *oflag* should be the read/write mode,
+        defaults to `os.O_RDWR`. *maxsize* is an integer that sets
         the upperbound limit on the number of items that can be placed in
         the queue (maximum value depends on system limit). *maxmsgsize*
         is a maximum size of the message in bytes (maximum value depends

--- a/ipcqueue/posixmq.py
+++ b/ipcqueue/posixmq.py
@@ -1,6 +1,7 @@
 """
 Interprocess POSIX message queue implementation.
 """
+import os
 
 from .serializers import PickleSerializer
 
@@ -73,7 +74,7 @@ class Queue(object):
     POSIX message queue.
     """
 
-    def __init__(self, name, maxsize=10, maxmsgsize=1024, serializer=PickleSerializer):
+    def __init__(self, name, oflag=os.O_RDWR, maxsize=10, maxmsgsize=1024, serializer=PickleSerializer):
         """
         Constructor for message queue. *name* is an unique identifier of the
         queue, must starts with ``/``. *maxsize* is an integer that sets
@@ -84,7 +85,8 @@ class Queue(object):
         """
         queue_name = ffi.new('char[]', name.encode('utf-8'))
         queue_id = ffi.new('int *')
-        res = lib.posixmq_open(queue_name, queue_id, maxmsgsize, maxsize)
+        #queue_oflag = ffi.new('int', oflag)
+        res = lib.posixmq_open(queue_name, oflag, queue_id, maxmsgsize, maxsize)
         if res != lib.POSIXMQ_OK:
             raise QueueError(res)
         self._queue_id = queue_id[0]


### PR DESCRIPTION
the flag allows to specify the READ/WRITE mode, the values can be
fetched from `os` module (`os.O_RDWR` default, `os.O_RDONLY`, `os.O_WRONLY`).

With the default value (tested on Fedora 38), two processes can't open
the same queue, failing with `EACCESS`. (The implementation may not allow two writers)